### PR TITLE
Suppress warning(s)

### DIFF
--- a/EMSimilarity.swift
+++ b/EMSimilarity.swift
@@ -56,7 +56,7 @@ class EMSimilarity {
     /** Pop the currentSimMode via pop if it won't make the stack empty **/
     func popSimMode() {
         if self.currentSimMode.count > 1 {
-            if let _ = self.currentSimMode.popLast()
+            let _ = self.currentSimMode.popLast()
         }
     }
     
@@ -76,7 +76,7 @@ class EMSimilarity {
     /** Pop the currentMismatchMode via pop if it won't make the stack empty **/
     func popMismatchMode() {
         if self.currentMismatchMode.count > 1 {
-            if let _ = self.currentMismatchMode.popLast()
+            let _ = self.currentMismatchMode.popLast()
         }
     }
     

--- a/EMSimilarity.swift
+++ b/EMSimilarity.swift
@@ -56,7 +56,7 @@ class EMSimilarity {
     /** Pop the currentSimMode via pop if it won't make the stack empty **/
     func popSimMode() {
         if self.currentSimMode.count > 1 {
-            self.currentSimMode.popLast()
+            if let _ = self.currentSimMode.popLast()
         }
     }
     
@@ -76,7 +76,7 @@ class EMSimilarity {
     /** Pop the currentMismatchMode via pop if it won't make the stack empty **/
     func popMismatchMode() {
         if self.currentMismatchMode.count > 1 {
-            self.currentMismatchMode.popLast()
+            if let _ = self.currentMismatchMode.popLast()
         }
     }
     


### PR DESCRIPTION
Prevents the warning ‘Result of call to `.popLast()` is unused'.

---

Screenshots of the warning(s) previously being produced included below.

![warnings](https://cloud.githubusercontent.com/assets/337963/24464450/e9d2c7c0-1477-11e7-90fb-cd96b90515c7.png)
